### PR TITLE
Fix new repos set to public by default

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,9 +15,6 @@ repository:
   # A comma-separated list of topics to set on the repository
   #topics: github, probot
 
-  # Either `true` to make the repository private, or `false` to make it public.
-  private: false
-
   # Either `true` to enable issues for this repository, `false` to disable them.
   has_issues: true
 


### PR DESCRIPTION
Moved to fork => https://github.com/epsagon/.github/pull/1