### PR TITLE
Add template community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,15 @@
+# CODEOWNERS reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the following users/teams will be requested for
+# review when someone opens a pull request.
+#
+# Maintainers
+# - Jason DeTiberus (@detiber)
+# - Stephen Augustus (@justaugustus)
+* @cisco-open/org-admins
+
 # Enforces admin protections for repo configuration via probot settings app.
 # ref: https://github.com/probot/settings#security-implications
 .github/settings.yml @cisco-open/org-admins

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+Please provide a description of the problem.
+
+## Expected Behavior
+
+Please describe what you expected would happen.
+
+## Actual Behavior
+
+Please describe what happened instead.
+
+## Affected Version
+
+Please provide the version number where this issue was encountered.
+
+## Steps to Reproduce
+
+1. First step
+1. Second step
+1. etc.
+
+## Checklist
+
+<!-- TODO: Update the link below to point to your project's contributing guidelines -->
+- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
+- [ ] I have verified this does not duplicate an existing issue

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest a feature for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Problem Statement
+
+Please describe the problem to be addressed by the proposed feature.
+
+## Proposed Solution
+
+Please describe what you envision the solution to this problem would look like.
+
+## Alternatives Considered
+
+Please briefly describe which alternatives, if any, have been considered, including merits of alternate approaches and
+tradeoffs being made.
+
+## Additional Context
+
+Please provide any other information that may be relevant.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Description
+
+Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
+related issues, other PRs, or technical references.
+
+Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
+change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.
+
+## Type of Change
+
+- [ ] Bug Fix
+- [ ] New Feature
+- [ ] Breaking Change
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Other (please describe)
+
+## Checklist
+
+<!-- TODO: Update the link below to point to your project's contributing guidelines -->
+- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
+- [ ] Existing issues have been referenced (where applicable)
+- [ ] I have verified this change is not present in other open pull requests
+- [ ] Functionality is documented
+- [ ] All code style checks pass
+- [ ] New code contribution is covered by automated tests
+- [ ] All new and existing tests pass

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # .github
+
+## About this repository
+
+This repository contains [community health files][creating-default-community-health-files]
+and workflow configurations which can be inherited by other repositories within
+this organization.
+
+## Acknowledgements
+
+The template documentation in this repo was adapted from:
+
+- https://github.com/wayfair-incubator/oss-template
+- https://github.com/othneildrew/Best-README-Template
+
+[creating-default-community-health-files]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [oss-conduct@cisco.com][conduct-email]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+[conduct-email]: mailto:oss-conduct@cisco.com
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# How to Contribute
+
+Thanks for your interest in contributing to `<project name>`! Here are a few general guidelines on contributing and
+reporting bugs that we ask you to review. Following these guidelines helps to communicate that you respect the time of
+the contributors managing and developing this open source project. In return, they should reciprocate that respect in
+addressing your issue, assessing changes, and helping you finalize your pull requests. In that spirit of mutual respect,
+we endeavor to review incoming issues and pull requests within 10 days, and will close any lingering issues or pull
+requests after 60 days of inactivity.
+
+Please note that all of your interactions in the project are subject to our [Code of Conduct](/CODE_OF_CONDUCT.md). This
+includes creation of issues or pull requests, commenting on issues or pull requests, and extends to all interactions in
+any real-time space e.g., Slack, Discord, etc.
+
+## Reporting Issues
+
+Before reporting a new issue, please ensure that the issue was not already reported or fixed by searching through our
+[issues list](https://github.com/org_name/repo_name/issues).
+
+When creating a new issue, please be sure to include a **title and clear description**, as much relevant information as
+possible, and, if possible, a test case.
+
+**If you discover a security bug, please do not report it through GitHub. Instead, please see security procedures in
+[SECURITY.md](/SECURITY.md).**
+
+## Sending Pull Requests
+
+Before sending a new pull request, take a look at existing pull requests and issues to see if the proposed change or fix
+has been discussed in the past, or if the change was already implemented but not yet released.
+
+We expect new pull requests to include tests for any affected behavior, and, as we follow semantic versioning, we may
+reserve breaking changes until the next major version release.
+
+## Other Ways to Contribute
+
+We welcome anyone that wants to contribute to `<project name>` to triage and reply to open issues to help troubleshoot
+and fix existing bugs. Here is what you can do:
+
+- Help ensure that existing issues follows the recommendations from the _[Reporting Issues](#reporting-issues)_ section,
+  providing feedback to the issue's author on what might be missing.
+- Review and update the existing content of our [Wiki](https://github.com/org_name/repo_name/wiki) with up-to-date
+  instructions and code samples.
+- Review existing pull requests, and testing patches against real existing applications that use `<project name>`.
+- Write a test, or add a missing test case to an existing test.
+
+Thanks again for your interest on contributing to `<project name>`!
+
+:heart:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the
+`<project name>` project.
+
+- [Reporting a Bug](#reporting-a-bug)
+- [Disclosure Policy](#disclosure-policy)
+- [Comments on this Policy](#comments-on-this-policy)
+
+## Reporting a Bug
+
+The `<project name>` team and community take all security bugs in
+`<project name>` seriously. Thank you for improving the security of
+`<project name>`. We appreciate your efforts and responsible disclosure and
+will make every effort to acknowledge your contributions.
+
+Report security bugs by emailing `oss-security@cisco.com`.
+
+The lead maintainer will acknowledge your email within 48 hours, and will send a
+more detailed response within 48 hours indicating the next steps in handling
+your report. After the initial reply to your report, the security team will
+endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+- Confirm the problem and determine the affected versions.
+- Audit code to find any potential similar problems.
+- Prepare fixes for all releases still under maintenance. These fixes will be
+  released as quickly as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.


### PR DESCRIPTION
Partially addressed by https://github.com/cisco-open/.github/issues/3.

- .github: Add issue and pull request templates
- docs: Add initial security policy
- docs: Add initial contribution guide
- docs: Add Code of Conduct (Contributor Covenant v1.4)
- Update README with purpose and attributions
- CODEOWNERS: Add wildcard entry for all files

Signed-off-by: Stephen Augustus <foo@auggie.dev>

