### PR TITLE
settings: Don't default repo visibility to `public`

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -16,7 +16,7 @@ repository:
   #topics: github, probot
 
   # Either `true` to make the repository private, or `false` to make it public.
-  private: false
+  #private: false
 
   # Either `true` to enable issues for this repository, `false` to disable them.
   has_issues: true


### PR DESCRIPTION
## Description

This setting automatically sets new repositories in the organization to `public`. It does not matter if the repo was explicitly set to `internal` or `private`. The bot changes the repo to `public`. It can easily cause proprietary data to be exposed if the creator of the repo doesn't catch it in time before the first push.

(Same functionality as https://github.com/epsagon/.github/pull/1.)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

## Type of Change

- [x] Bug Fix

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
